### PR TITLE
rbac: Add NetworkAttachmentDefinition editor cluster-role

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- net_attach_def_editor_role.yaml
+- net_attach_def_editor_role_binding.yaml

--- a/config/rbac/net_attach_def_editor_role.yaml
+++ b/config/rbac/net_attach_def_editor_role.yaml
@@ -1,0 +1,12 @@
+---
+kind: ClusterRole
+metadata:
+  name: net-attach-def-editor
+rules:
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - create
+  - delete

--- a/config/rbac/net_attach_def_editor_role_binding.yaml
+++ b/config/rbac/net_attach_def_editor_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: net-attach-def-editor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: net-attach-def-editor
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
The controller need to manage net-attach-def objects to create overlay-networks using OVN Kubernets CNI.

Add ClusterRole and ClusterRoleBinding for create/delete net-attach-def objects.

The RBAC Kustomization manifest is updated to interpret the new objects.