### PR TITLE
Add Makefile cluster sync target

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,7 +4,3 @@
 resources:
 - bases/self.service.ovn.org_overlaynetworks.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
-
-# the following config is for teaching kustomize how to do kustomization for CRDs.
-configurations:
-- kustomizeconfig.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manager.yaml
+images:
+- name: controller
+  newName: localhost/overlay-network-controller
+  newTag: devel


### PR DESCRIPTION
Cluster sync build the controller and deploy it to the local cluster
enabling faster iterations.

Introduce 'kind-push' target, it enables pushing the controller image
to cluster nodes container runtime local registry using KinD.

cluster-sync flow:
- Remove the installed CRDs, Deployment and all related object (namesapce, sa, rbac, etc..)
- Generate manifest (CRD, RBAC, etc..).
- Generates code (DeepCopy, etc..).
- go fmt, go vet
- Deploy the controller CRDs.
- Build controller the image.
- Push the image to cluster nodes container runtime local registry (using KinD).
- Generate manifests (Namespace, SA, Deployment, etc.., using Kustomize)
- Deploy controller and all related objects.

The default container image tag, represented by $IMG, is changed as follows to
make kind load work as expected:
  'localhost/overlay-network-controller:devel'