### PR TITLE
manifests: Remove 'app.kubernetes.io' labels

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,12 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: namespace
-    app.kubernetes.io/instance: system
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: selfserviceoverlay
-    app.kubernetes.io/part-of: selfserviceoverlay
-    app.kubernetes.io/managed-by: kustomize
   name: system
 ---
 apiVersion: apps/v1
@@ -18,12 +12,6 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: selfserviceoverlay
-    app.kubernetes.io/part-of: selfserviceoverlay
-    app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,13 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: selfserviceoverlay
-    app.kubernetes.io/part-of: selfserviceoverlay
-    app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,12 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: selfserviceoverlay
-    app.kubernetes.io/part-of: selfserviceoverlay
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/self.service_v1_overlaynetwork.yaml
+++ b/config/samples/self.service_v1_overlaynetwork.yaml
@@ -1,12 +1,6 @@
 apiVersion: self.service.ovn.org/v1
 kind: OverlayNetwork
 metadata:
-  labels:
-    app.kubernetes.io/name: overlaynetwork
-    app.kubernetes.io/instance: overlaynetwork-sample
-    app.kubernetes.io/part-of: selfserviceoverlay
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: selfserviceoverlay
   name: overlaynetwork-sample
 spec:
   # TODO(user): Add fields here


### PR DESCRIPTION
The 'app.kubernetes.io' labels helps in managing and filtering relevant objects in a production cluster where there are lots of workload of various kinds [1].

Remove 'app.kubernetes.io' labels as we do not need them at the moment.

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels