### PR TITLE
controller, overlay-network reconciler: Create NetworkAttachmetDefinition 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ go.work
 
 # ovn-org/ovn-kubernetes repo clone
 automation/_ovn-k8s/
+
+# Go mod vendor
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/Makefile
+++ b/Makefile
@@ -273,3 +273,8 @@ kind-push:
 
 .PHONY: cluster-sync
 cluster-sync: undeploy uninstall manifests generate fmt vet docker-build kind-push install deploy
+
+.PHONY: vendor
+vendor:
+	go mod tidy
+	go mod vendor

--- a/config/rbac/net_attach_def_editor_role.yaml
+++ b/config/rbac/net_attach_def_editor_role.yaml
@@ -1,4 +1,5 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: net-attach-def-editor

--- a/config/rbac/net_attach_def_editor_role.yaml
+++ b/config/rbac/net_attach_def_editor_role.yaml
@@ -11,3 +11,6 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - watch

--- a/controllers/overlaynetwork_controller.go
+++ b/controllers/overlaynetwork_controller.go
@@ -18,11 +18,17 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
 )
@@ -47,9 +53,39 @@ type OverlayNetworkReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *OverlayNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	overlayNetwork := &selfservicev1.OverlayNetwork{}
+	if err := r.Client.Get(ctx, req.NamespacedName, overlayNetwork); err != nil {
+		if !errors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get OverlayNetwork %q: %v", req.NamespacedName, err)
+		}
+		return ctrl.Result{}, nil
+	}
 
-	// TODO(user): your logic here
+	if overlayNetwork.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	desiredNetAttachDef := renderNetAttachDef(overlayNetwork)
+
+	actualNetAttachDef := &netv1.NetworkAttachmentDefinition{}
+	actualKey := client.ObjectKey{Namespace: overlayNetwork.Namespace, Name: overlayNetwork.Name}
+	if gerr := r.Client.Get(ctx, actualKey, actualNetAttachDef); gerr != nil {
+		if !errors.IsNotFound(gerr) {
+			return ctrl.Result{}, fmt.Errorf("failed to get NetworkAttachmetDefinition: %v", gerr)
+		}
+		if cerr := r.Client.Create(ctx, desiredNetAttachDef); cerr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create NetworkAttachmetDefinition: %v", cerr)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !hasOwnerReferenceWithUID(overlayNetwork.UID, actualNetAttachDef.OwnerReferences) {
+		return ctrl.Result{}, fmt.Errorf("foreign NetworkAttachmetDefinition with the desired name already exist")
+	}
+
+	if actualNetAttachDef.Spec.Config != desiredNetAttachDef.Spec.Config {
+		return ctrl.Result{}, fmt.Errorf("mutating NetworkAttachmetDefinition is not possible")
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -59,4 +95,44 @@ func (r *OverlayNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&selfservicev1.OverlayNetwork{}).
 		Complete(r)
+}
+
+func renderNetAttachDef(overlayNet *selfservicev1.OverlayNetwork) *netv1.NetworkAttachmentDefinition {
+	const netAttachDefKind = "NetworkAttachmentDefinition"
+	const netAttachDefAPIVer = "v1"
+	// TODO: set config
+	netConf := ""
+
+	blockOwnerDeletion := true
+	return &netv1.NetworkAttachmentDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: netAttachDefAPIVer,
+			Kind:       netAttachDefKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      overlayNet.Name,
+			Namespace: overlayNet.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         overlayNet.APIVersion,
+					Kind:               overlayNet.Kind,
+					Name:               overlayNet.Name,
+					UID:                overlayNet.UID,
+					BlockOwnerDeletion: &blockOwnerDeletion,
+				},
+			},
+		},
+		Spec: netv1.NetworkAttachmentDefinitionSpec{
+			Config: netConf,
+		},
+	}
+}
+
+func hasOwnerReferenceWithUID(uid types.UID, ownerRefs []metav1.OwnerReference) bool {
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.UID == uid {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/overlaynetwork_controller.go
+++ b/controllers/overlaynetwork_controller.go
@@ -18,11 +18,7 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net"
-	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +31,8 @@ import (
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
+
+	"github.com/AlonaKaplan/selfserviceoverlay/pkg/render"
 )
 
 // OverlayNetworkReconciler reconciles a OverlayNetwork object
@@ -69,7 +67,7 @@ func (r *OverlayNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	desiredNetAttachDef, err := renderNetAttachDef(overlayNetwork)
+	desiredNetAttachDef, err := render.NetAttachDef(overlayNetwork)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render NetworkAttachmentDefinition for OverlayNetwork %q: %v", req.NamespacedName, err)
 	}
@@ -102,100 +100,6 @@ func (r *OverlayNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&selfservicev1.OverlayNetwork{}).
 		Complete(r)
-}
-
-func renderNetAttachDef(overlayNet *selfservicev1.OverlayNetwork) (*netv1.NetworkAttachmentDefinition, error) {
-	cniNetConf, err := renderCNINetworkConfig(overlayNet)
-	if err != nil {
-		return nil, err
-	}
-	cniNetConfRaw, err := json.Marshal(cniNetConf)
-	if err != nil {
-		return nil, err
-	}
-
-	const netAttachDefKind = "NetworkAttachmentDefinition"
-	const netAttachDefAPIVer = "v1"
-	blockOwnerDeletion := true
-	return &netv1.NetworkAttachmentDefinition{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: netAttachDefAPIVer,
-			Kind:       netAttachDefKind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      overlayNet.Name,
-			Namespace: overlayNet.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         overlayNet.APIVersion,
-					Kind:               overlayNet.Kind,
-					Name:               overlayNet.Name,
-					UID:                overlayNet.UID,
-					BlockOwnerDeletion: &blockOwnerDeletion,
-				},
-			},
-		},
-		Spec: netv1.NetworkAttachmentDefinitionSpec{
-			Config: string(cniNetConfRaw),
-		},
-	}, nil
-}
-
-func renderCNINetworkConfig(overlayNet *selfservicev1.OverlayNetwork) (map[string]interface{}, error) {
-	const (
-		cniVersionKey       = "cniVersion"
-		cniVersion          = "0.3.1"
-		topologyKey         = "topology"
-		topologyLayer2      = "layer2"
-		typeKey             = "type"
-		ovnK8sCniOverlay    = "ovn-k8s-cni-overlay"
-		nameKey             = "name"
-		netAttachDefNameKey = "netAttachDefName"
-	)
-	cniNetConf := map[string]interface{}{
-		cniVersionKey:       cniVersion,
-		typeKey:             ovnK8sCniOverlay,
-		nameKey:             overlayNet.Namespace + "-" + overlayNet.Spec.Name,
-		netAttachDefNameKey: overlayNet.Namespace + "/" + overlayNet.Name,
-		topologyKey:         topologyLayer2,
-	}
-
-	if overlayNet.Spec.Mtu != "" {
-		mtu, err := strconv.Atoi(overlayNet.Spec.Mtu)
-		if err != nil {
-			return nil, err
-		}
-		const mtuKey = "mtu"
-		cniNetConf[mtuKey] = mtu
-	}
-
-	if overlayNet.Spec.Subnets != "" {
-		if err := validateSubnets(overlayNet.Spec.Subnets); err != nil {
-			return nil, err
-		}
-		const subnetsKey = "subnets"
-		cniNetConf[subnetsKey] = overlayNet.Spec.Subnets
-	}
-
-	if overlayNet.Spec.ExcludeSubnets != "" {
-		if err := validateSubnets(overlayNet.Spec.ExcludeSubnets); err != nil {
-			return nil, err
-		}
-		const excludeSubnetsKey = "excludeSubnets"
-		cniNetConf[excludeSubnetsKey] = overlayNet.Spec.ExcludeSubnets
-	}
-
-	return cniNetConf, nil
-}
-
-func validateSubnets(subnets string) error {
-	subentsSlice := strings.Split(subnets, ",")
-	for _, subent := range subentsSlice {
-		if _, _, err := net.ParseCIDR(subent); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func hasOwnerReferenceWithUID(uid types.UID, ownerRefs []metav1.OwnerReference) bool {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/AlonaKaplan/selfserviceoverlay
 go 1.19
 
 require (
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	k8s.io/apimachinery v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ import (
 	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
 	"github.com/AlonaKaplan/selfserviceoverlay/controllers"
 	//+kubebuilder:scaffold:imports
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
 )
 
 var (
@@ -45,6 +47,8 @@ func init() {
 
 	utilruntime.Must(selfservicev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+
+	utilruntime.Must(netv1.AddToScheme(scheme))
 }
 
 func main() {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,0 +1,108 @@
+package render
+
+import (
+	"encoding/json"
+	"net"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
+)
+
+func NetAttachDef(overlayNet *selfservicev1.OverlayNetwork) (*netv1.NetworkAttachmentDefinition, error) {
+	cniNetConf, err := renderCNINetworkConfig(overlayNet)
+	if err != nil {
+		return nil, err
+	}
+	cniNetConfRaw, err := json.Marshal(cniNetConf)
+	if err != nil {
+		return nil, err
+	}
+
+	const netAttachDefKind = "NetworkAttachmentDefinition"
+	const netAttachDefAPIVer = "v1"
+	blockOwnerDeletion := true
+	return &netv1.NetworkAttachmentDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: netAttachDefAPIVer,
+			Kind:       netAttachDefKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      overlayNet.Name,
+			Namespace: overlayNet.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         overlayNet.APIVersion,
+					Kind:               overlayNet.Kind,
+					Name:               overlayNet.Name,
+					UID:                overlayNet.UID,
+					BlockOwnerDeletion: &blockOwnerDeletion,
+				},
+			},
+		},
+		Spec: netv1.NetworkAttachmentDefinitionSpec{
+			Config: string(cniNetConfRaw),
+		},
+	}, nil
+}
+
+func renderCNINetworkConfig(overlayNet *selfservicev1.OverlayNetwork) (map[string]interface{}, error) {
+	const (
+		cniVersionKey       = "cniVersion"
+		cniVersion          = "0.3.1"
+		topologyKey         = "topology"
+		topologyLayer2      = "layer2"
+		typeKey             = "type"
+		ovnK8sCniOverlay    = "ovn-k8s-cni-overlay"
+		nameKey             = "name"
+		netAttachDefNameKey = "netAttachDefName"
+	)
+	cniNetConf := map[string]interface{}{
+		cniVersionKey:       cniVersion,
+		typeKey:             ovnK8sCniOverlay,
+		nameKey:             overlayNet.Namespace + "-" + overlayNet.Spec.Name,
+		netAttachDefNameKey: overlayNet.Namespace + "/" + overlayNet.Name,
+		topologyKey:         topologyLayer2,
+	}
+
+	if overlayNet.Spec.Mtu != "" {
+		mtu, err := strconv.Atoi(overlayNet.Spec.Mtu)
+		if err != nil {
+			return nil, err
+		}
+		const mtuKey = "mtu"
+		cniNetConf[mtuKey] = mtu
+	}
+
+	if overlayNet.Spec.Subnets != "" {
+		if err := validateSubnets(overlayNet.Spec.Subnets); err != nil {
+			return nil, err
+		}
+		const subnetsKey = "subnets"
+		cniNetConf[subnetsKey] = overlayNet.Spec.Subnets
+	}
+
+	if overlayNet.Spec.ExcludeSubnets != "" {
+		if err := validateSubnets(overlayNet.Spec.ExcludeSubnets); err != nil {
+			return nil, err
+		}
+		const excludeSubnetsKey = "excludeSubnets"
+		cniNetConf[excludeSubnetsKey] = overlayNet.Spec.ExcludeSubnets
+	}
+
+	return cniNetConf, nil
+}
+
+func validateSubnets(subnets string) error {
+	subentsSlice := strings.Split(subnets, ",")
+	for _, subent := range subentsSlice {
+		if _, _, err := net.ParseCIDR(subent); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
On update/create of OverlayNetwork, create corresponding
NetworkAttachmentDefinition.

The NetworkAttachmentDefinition is created with OwnerReference [1] pointing to
the reconciled object.
Once the reconciled object is deleted the corresponding net-attach-def object
is deleted as well by the cluster garbage collector.

This change sets basic the net-attach-def CNI network config.