### PR TITLE
tests: Add E2E test for net-attach-def lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,3 +272,7 @@ kind-push:
 
 .PHONY: cluster-sync
 cluster-sync: undeploy uninstall manifests generate fmt vet docker-build kind-push install deploy
+
+.PHONY: functest
+functest:
+	go test -v ./e2e/...

--- a/config/rbac/net_attach_def_editor_role.yaml
+++ b/config/rbac/net_attach_def_editor_role.yaml
@@ -1,4 +1,5 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: net-attach-def-editor

--- a/e2e/net-attach-def_test.go
+++ b/e2e/net-attach-def_test.go
@@ -1,0 +1,81 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
+)
+
+const overlayNetworkKind = "OverlayNetwork"
+
+var _ = Describe("OverlayNetwork controller, net-attach-def lifecycle", func() {
+	It("should create and delete net-attach-def according to OverlayNetwork state", func() {
+		By("Create test OverlayNetwork instance")
+		ovrlyNet := newTestOverlayNetwork(TestsNamespace, "test")
+		Expect(RuntimeClient.Create(context.Background(), ovrlyNet)).To(Succeed())
+
+		By("Assert a corresponding net-attach-def has been created")
+		nad := &netv1.NetworkAttachmentDefinition{}
+		nadKey := types.NamespacedName{Namespace: ovrlyNet.Namespace, Name: ovrlyNet.Name}
+		Eventually(func() error {
+			return RuntimeClient.Get(context.Background(), nadKey, nad)
+		}).Should(Succeed(), "1m", "3s")
+
+		By("Assert overlay-network corresponding net-attach-def object")
+		assertOverlayNetworkNetAttachDef(ovrlyNet, nad)
+
+		By("Delete test OverlayNetwork instance")
+		Expect(RuntimeClient.Delete(context.Background(), ovrlyNet)).To(Succeed())
+
+		By("Assert the corresponding net-attach-def is deleted by and not exist")
+		Eventually(func() bool {
+			return errors.IsNotFound(RuntimeClient.Get(context.Background(), nadKey, nad))
+		}).Should(BeTrue(), "1m", "3s",
+			"the overlay-network corresponding net-attach-def should be disposed")
+	})
+})
+
+func assertOverlayNetworkNetAttachDef(overlyNet *selfservicev1.OverlayNetwork, nad *netv1.NetworkAttachmentDefinition) {
+	expectedNetAttachName := overlyNet.Namespace + "/" + overlyNet.Name
+	expectedCniNetConf := fmt.Sprintf(`{	
+		"name":"test",
+		"type":"ovn-k8s-cni-overlay",				
+		"netAttachDefName": "%s",
+		"topology":"layer2"
+	}`, expectedNetAttachName)
+
+	Expect(nad.Spec.Config).To(MatchJSON(expectedCniNetConf))
+
+	expectedOwnerReference := metav1.OwnerReference{
+		APIVersion: selfservicev1.GroupVersion.String(), // "self.service.ovn.org/netv1",
+		Kind:       overlayNetworkKind,
+		Name:       overlyNet.Name,
+		UID:        overlyNet.UID,
+	}
+
+	Expect(nad.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{expectedOwnerReference}))
+}
+
+func newTestOverlayNetwork(namespace, name string) *selfservicev1.OverlayNetwork {
+	return &selfservicev1.OverlayNetwork{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       overlayNetworkKind,
+			APIVersion: selfservicev1.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: selfservicev1.OverlayNetworkSpec{},
+	}
+}

--- a/e2e/selfserviceoverlay_suite_test.go
+++ b/e2e/selfserviceoverlay_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSelfserviceoverlay(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Selfserviceoverlay Suite")
+}

--- a/e2e/selfserviceoverlay_suite_test.go
+++ b/e2e/selfserviceoverlay_suite_test.go
@@ -1,13 +1,71 @@
-package main_test
+package e2e
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
+)
+
+const TestsNamespace = "overlay-network-tests"
+
+var (
+	KubeClient    *kubernetes.Clientset
+	RuntimeClient client.Client
 )
 
 func TestSelfserviceoverlay(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Selfserviceoverlay Suite")
 }
+
+var _ = BeforeSuite(func() {
+	cfg, err := config.GetConfig()
+	Expect(err).ToNot(HaveOccurred(), "failed to get configuration for existing cluster")
+	Expect(cfg).ToNot(BeNil())
+
+	err = selfservicev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = netv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	KubeClient, err = kubernetes.NewForConfig(cfg)
+	Expect(KubeClient).ToNot(BeNil())
+
+	RuntimeClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(RuntimeClient).ToNot(BeNil())
+
+	By("create tests namespace")
+	testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TestsNamespace}}
+	_, err = KubeClient.CoreV1().Namespaces().Create(context.Background(), testNamespace, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("delete tests namespace")
+	err := KubeClient.CoreV1().Namespaces().Delete(context.Background(), TestsNamespace, metav1.DeleteOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	By("wait for tests namespace to dispose")
+	Eventually(func() bool {
+		_, err := KubeClient.CoreV1().Namespaces().Get(context.Background(), TestsNamespace, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, "30s", "1s").Should(BeTrue(), "tests namespace should be disposed")
+})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/AlonaKaplan/selfserviceoverlay
 go 1.19
 
 require (
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	k8s.io/apimachinery v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ import (
 	selfservicev1 "github.com/AlonaKaplan/selfserviceoverlay/api/v1"
 	"github.com/AlonaKaplan/selfserviceoverlay/controllers"
 	//+kubebuilder:scaffold:imports
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
 )
 
 var (
@@ -45,6 +47,8 @@ func init() {
 
 	utilruntime.Must(selfservicev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+
+	utilruntime.Must(netv1.AddToScheme(scheme))
 }
 
 func main() {


### PR DESCRIPTION
**Rebased on (#13, first five commits)**

This PR bootstrap Ginkgo e2e test suite and tests the `OverlayNetwork` corresponding `NetworkAttachmentDefinition` lifecycle; where the controller create/delete NAD when OverlayNetwork is created/delteted.

The test suite create Namspace "overlay-network-tests"  for tests and deletes it when the test suite finish.

How to run tests: 
`make functests`
